### PR TITLE
Add contact page with safe actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# UniVerse
+
+## Landing Page Design Highlights
+
+- **Dynamic Gradient Background** – the hero section features a dark gradient backdrop with a radial red glow and dotted pattern overlay.
+- **Animated Floating Blobs** – translucent red blobs animate around the screen using Framer Motion for subtle movement.
+- **Animated Hero Content** – headings, sub‑text and buttons fade and slide in with staggered animations.
+- **Gradient CTA Button** – main call‑to‑action uses a red gradient button that scales on hover.
+- **Optional Video Button** – a secondary outline style button can link to a video.
+- **Statistics Grid** – animated numbers show stats below the hero text.
+- **Diagonal Divider** – the bottom of the hero section ends with a diagonal SVG divider.
+
+The rest of the site uses Tailwind CSS and Framer Motion for smooth transitions.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "framer-motion": "^12.19.2",
     "lucide-react": "^0.513.0",
     "next": "15.3.4",
+    "next-safe-action": "^8.0.7",
     "next-themes": "^0.4.6",
     "payload": "^3.43.0",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       next:
         specifier: 15.3.4
         version: 15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+      next-safe-action:
+        specifier: ^8.0.7
+        version: 8.0.7(next@15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3038,6 +3041,14 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  next-safe-action@8.0.7:
+    resolution: {integrity: sha512-clQRxsvf4nZktCYkP1seeNH5rOZjsx6VYSAlpphvXvW+INIBvGySEStKutwtAPFV0/uZFJmNPt77ankoepUYXQ==}
+    engines: {node: '>=18.17'}
+    peerDependencies:
+      next: '>= 14.0.0'
+      react: '>= 18.2.0'
+      react-dom: '>= 18.2.0'
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -7122,6 +7133,12 @@ snapshots:
   napi-postinstall@0.2.4: {}
 
   natural-compare@1.4.0: {}
+
+  next-safe-action@8.0.7(next@15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      next: 15.3.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.77.4)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/actions/contact.ts
+++ b/src/actions/contact.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { z } from "zod";
+import { action } from "~/lib/safe-action";
+import payloadClient from "~/data-access";
+
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  message: z.string().min(1),
+});
+
+export const submitContact = action
+  .metadata({ actionName: "submitContact" })
+  .inputSchema(schema)
+  .action(async ({ parsedInput }) => {
+    const payload = await payloadClient();
+    await payload.create({ collection: "contacts", data: parsedInput });
+    return { success: true };
+  });

--- a/src/app/(app)/contact/page.tsx
+++ b/src/app/(app)/contact/page.tsx
@@ -1,0 +1,12 @@
+import ContactForm from "~/components/contact-form";
+
+export const metadata = { title: "Contact" };
+
+export default function ContactPage() {
+  return (
+    <div className="mx-auto max-w-xl px-4 py-20">
+      <h1 className="mb-6 text-3xl font-bold">Contact Us</h1>
+      <ContactForm />
+    </div>
+  );
+}

--- a/src/collections/Contact.ts
+++ b/src/collections/Contact.ts
@@ -1,0 +1,37 @@
+import type { CollectionConfig, AfterChangeHook } from "payload/types";
+import sendDiscordWebhook from "~/lib/discordWebhook";
+
+const notifyDiscord: AfterChangeHook = async ({ doc, operation }) => {
+  if (operation === "create") {
+    await sendDiscordWebhook(doc);
+  }
+};
+
+export const Contacts: CollectionConfig = {
+  slug: "contacts",
+  admin: {
+    useAsTitle: "email",
+  },
+  fields: [
+    {
+      name: "name",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "email",
+      type: "email",
+      required: true,
+    },
+    {
+      name: "message",
+      type: "textarea",
+      required: true,
+    },
+  ],
+  hooks: {
+    afterChange: [notifyDiscord],
+  },
+};
+
+export default Contacts;

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { useAction } from "next-safe-action/hooks";
+import { submitContact } from "~/actions/contact";
+import { Button } from "~/components/ui/button";
+
+export default function ContactForm() {
+  const { execute, status, result, reset } = useAction(submitContact);
+  const [form, setForm] = useState({ name: "", email: "", message: "" });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        execute(form);
+      }}
+      className="flex flex-col gap-4"
+    >
+      <input
+        type="text"
+        className="rounded-md border border-gray-300 p-2"
+        placeholder="Name"
+        value={form.name}
+        onChange={(e) => setForm({ ...form, name: e.target.value })}
+        required
+      />
+      <input
+        type="email"
+        className="rounded-md border border-gray-300 p-2"
+        placeholder="Email"
+        value={form.email}
+        onChange={(e) => setForm({ ...form, email: e.target.value })}
+        required
+      />
+      <textarea
+        className="rounded-md border border-gray-300 p-2"
+        placeholder="Message"
+        value={form.message}
+        onChange={(e) => setForm({ ...form, message: e.target.value })}
+        required
+      />
+      <Button type="submit" disabled={status === "executing"}>
+        {status === "executing" ? "Sending..." : "Send"}
+      </Button>
+      {result?.data && (
+        <p className="text-green-600">Thank you for contacting us!</p>
+      )}
+      {result?.serverError && (
+        <p className="text-red-600">{result.serverError}</p>
+      )}
+    </form>
+  );
+}

--- a/src/lib/discordWebhook.ts
+++ b/src/lib/discordWebhook.ts
@@ -1,0 +1,11 @@
+export interface ContactPayload {
+  name: string;
+  email: string;
+  message: string;
+  [key: string]: unknown;
+}
+
+export default async function sendDiscordWebhook(_: ContactPayload) {
+  // Placeholder for future Discord webhook integration
+  return;
+}

--- a/src/lib/safe-action.ts
+++ b/src/lib/safe-action.ts
@@ -1,0 +1,3 @@
+import { createSafeActionClient } from "next-safe-action";
+
+export const action = createSafeActionClient();

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -3,6 +3,7 @@ import { lexicalEditor } from "@payloadcms/richtext-lexical";
 import { postgresAdapter } from "@payloadcms/db-postgres";
 import { buildConfig } from "payload";
 import { Users } from "~/collections/User";
+import { Contacts } from "~/collections/Contact";
 import { GHeroSection } from "~/globals/hero";
 import { GSettings } from "~/globals/settings";
 import { env } from "./env";
@@ -18,7 +19,7 @@ export default buildConfig({
     },
   },
   // Define and configure your collections in this array
-  collections: [Users],
+  collections: [Users, Contacts],
   globals: [GSettings, GHeroSection],
 
   // Your Payload secret - should be a complex and secure string, unguessable


### PR DESCRIPTION
## Summary
- document landing page design
- scaffold next-safe-action utilities
- add contact form page that uses safe action
- create Contact payload collection with after-create hook
- placeholder for discord webhook integration

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68726663c3bc8332b54e9da7bd41d2af